### PR TITLE
Fix GraphQL authorization

### DIFF
--- a/api/src/db/actions/user.js
+++ b/api/src/db/actions/user.js
@@ -34,7 +34,8 @@ export async function findOrCreateUser(user, provider) {
   }
 
   // No user found, create it
-  return await createUser({ ...user });
+  const newUserId = await createUser({ ...user });
+  return await findUserById(newUserId);
 }
 
 // ------------------------------
@@ -42,7 +43,10 @@ export async function findOrCreateUser(user, provider) {
 
 export async function createUser(userData) {
   try {
-    return await knex('users').insert(userData);
+    const [id] = await knex('users')
+      .insert(userData)
+      .returning('id');
+    return id;
   } catch (err) {
     if (err.code === POSTGRES_UNIQUE_VIOLATION) {
       if (err.constraint.includes('username'))

--- a/api/src/graphql/schema/user/resolvers.js
+++ b/api/src/graphql/schema/user/resolvers.js
@@ -1,17 +1,14 @@
-import {
-  baseResolver,
-  isAuthenticatedResolver,
-  isAdminResolver,
-} from '../../baseResolvers';
-import {
-  InvalidDataError,
-  UserAlreadyExists,
-  UserNotFound,
-  UnknownError,
-} from '../../errors';
+import { baseResolver, isAuthenticatedResolver } from '../../baseResolvers';
+import { findUserById } from '../../../db/actions/user';
 
-const me = isAuthenticatedResolver.createResolver(async (root, _, { user }) => {
-  return user;
+const me = baseResolver.createResolver(async (root, _, { user }) => {
+  if (!user) {
+    return null;
+  }
+
+  // Fetches the updated status of the user from DB instead of just returning
+  // the object from session
+  return await findUserById(user.id);
 });
 
 const userById = isAuthenticatedResolver.createResolver(


### PR DESCRIPTION
Now you can check if the user is logged in or not using the `me` query without permission errors. Other resolvers can retrieve the logged in user extracting the prop `user` from the context. You can protect a resolver with `isAuthenticatedResolver`.